### PR TITLE
Update Ruby to version 4.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,4 +180,4 @@ DEPENDENCIES
   zeitwerk (~> 2.8)
 
 BUNDLED WITH
-  4.0.13
+  4.0.16


### PR DESCRIPTION
This PR updates the Ruby version to 4.0.5.

Changes made:
- Updated .ruby-version file (if present)
- Updated .tool-versions file (if present)
- Updated Gemfile ruby version (if present)
- Updated Dockerfile ruby version (if present)
- Updated Gemfile.lock dependencies
- Updated bundler to latest version

Please review and test before merging.

Powered by [Ruby Upgrade Action](https://github.com/andrew/ruby-upgrade-action/)